### PR TITLE
fix: plentyDevTool link target

### DIFF
--- a/src/partials/header-content.hbs
+++ b/src/partials/header-content.hbs
@@ -19,7 +19,7 @@
                             <a class="submenu-item" href="/en-gb/plentyModules/stable7/versions.html">Active module versions</a>
                         </div>
                     </div>
-                    <a class="menu-item" href="/en-gb/plentydevtool/main/plentydevtool-introduction.html" target="_blank">plentyDevTool</a>
+                    <a class="menu-item" href="/en-gb/plentydevtool/main/plentydevtool-introduction.html">plentyDevTool</a>
                     <a class="menu-item" href="https://knowledge.plentymarkets.com/en" target="_blank">User manual</a>
                 </div>
                 <div class="search">


### PR DESCRIPTION
With this change, the plentyDevTool link no longer opens in a new tab.