### PR TITLE
fix: use lang as page attribute

### DIFF
--- a/preview-src/ui-model.yml
+++ b/preview-src/ui-model.yml
@@ -1,6 +1,5 @@
 antoraVersion: '1.0.0'
 site:
-  lang: de-de
   url: http://localhost:5252
   title: Brand Docs
   homeUrl: &home_url /xyz/5.2/index.html
@@ -56,6 +55,7 @@ page:
   url: *home_url
   home: true
   title: Brand&#8217;s Hardware &amp; Software Requirements
+  page-lang: de-de
   component: *component
   componentVersion: *component_version
   version: '5.2'

--- a/src/partials/toc.hbs
+++ b/src/partials/toc.hbs
@@ -1,3 +1,3 @@
-<aside class="toc sidebar" data-title="{{or page.attributes.toctitle i18n site.lang 'toctitle'}}" data-levels="{{{or page.attributes.toclevels 2}}}">
+<aside class="toc sidebar" data-title="{{or page.attributes.toctitle i18n page.attributes.lang 'toctitle'}}" data-levels="{{{or page.attributes.toclevels 2}}}">
   <div class="toc-menu"></div>
 </aside>


### PR DESCRIPTION
Fixes where to pull the language from as described [here](https://docs.antora.org/antora-ui-default/templates/):

<img width="804" alt="Screenshot 2022-01-11 at 12 32 37" src="https://user-images.githubusercontent.com/43753494/148935329-1496e22d-7661-4200-b1a7-5b95ad3b9144.png">