### PR TITLE
feat: overview layout

### DIFF
--- a/src/js/12-child-pages-list.js
+++ b/src/js/12-child-pages-list.js
@@ -1,4 +1,6 @@
 const currentPage = document.getElementsByClassName('is-current-page')
-let childPagesList = ''
+let childPagesList = document.createElement('div')
 childPagesList = currentPage[0].getElementsByClassName('nav-list')[0]
-document.getElementById('child-pages-list').appendChild(childPagesList)
+if (document.getElementById('child-pages-list')){
+    document.getElementById('child-pages-list').appendChild(childPagesList)
+}

--- a/src/js/12-child-pages-list.js
+++ b/src/js/12-child-pages-list.js
@@ -1,6 +1,6 @@
 const currentPage = document.getElementsByClassName('is-current-page')
 let childPagesList = document.createElement('div')
 childPagesList = currentPage[0].getElementsByClassName('nav-list')[0]
-if (document.getElementById('child-pages-list')){
-    document.getElementById('child-pages-list').appendChild(childPagesList)
+if (document.getElementById('child-pages-list')) {
+  document.getElementById('child-pages-list').appendChild(childPagesList)
 }

--- a/src/js/12-child-pages-list.js
+++ b/src/js/12-child-pages-list.js
@@ -1,0 +1,4 @@
+const currentPage = document.getElementsByClassName('is-current-page')
+let childPagesList = ''
+childPagesList = currentPage[0].getElementsByClassName('nav-list')[0]
+document.getElementById('child-pages-list').appendChild(childPagesList)

--- a/src/lang/de-de.json
+++ b/src/lang/de-de.json
@@ -1,5 +1,7 @@
 {
   "toctitle": "Inhalte",
+  "overview_page_intro_1": "Willkommen im Themenbereich",
+  "overview_page_intro_2": "Hier findest du folgende Informationen:",
 
   "developers-documentation": "Entwicklerdokumentation",
 

--- a/src/lang/en-gb.json
+++ b/src/lang/en-gb.json
@@ -1,5 +1,7 @@
 {
   "toctitle": "Contents",
+  "overview_page_intro_1": "Welcome to the section",
+  "overview_page_intro_2": "This section covers the following topics:",
 
   "developers-documentation": "Developers docs",
 

--- a/src/layouts/default.hbs
+++ b/src/layouts/default.hbs
@@ -1,11 +1,1 @@
-<!DOCTYPE html>
-<html lang="{{#if (eq page.attributes.lang 'de-de')}}de{{else}}en{{/if}}">
-  <head>
-{{> head defaultPageTitle='Untitled'}}
-  </head>
-  <body class="article{{#with (or page.attributes.role page.role)}} {{{this}}}{{/with}}">
-{{> header}}
-{{> body}}
-{{> footer}}
-  </body>
-</html>
+{{> default }}

--- a/src/layouts/overview.hbs
+++ b/src/layouts/overview.hbs
@@ -1,11 +1,1 @@
-<!DOCTYPE html>
-<html lang="{{#if (eq page.attributes.lang 'de-de')}}de{{else}}en{{/if}}">
-  <head>
-{{> head defaultPageTitle='Untitled'}}
-  </head>
-  <body class="article{{#with (or page.attributes.role page.role)}} {{{this}}}{{/with}}">
-{{> header}}
-{{> body}}
-{{> footer}}
-  </body>
-</html>
+{{> default }}

--- a/src/layouts/overview.hbs
+++ b/src/layouts/overview.hbs
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="{{#if (eq page.attributes.lang 'de-de')}}de{{else}}en{{/if}}">
+  <head>
+{{> head defaultPageTitle='Untitled'}}
+  </head>
+  <body class="article{{#with (or page.attributes.role page.role)}} {{{this}}}{{/with}}">
+{{> header}}
+{{> body}}
+{{> footer}}
+  </body>
+</html>

--- a/src/layouts/search.hbs
+++ b/src/layouts/search.hbs
@@ -1,11 +1,1 @@
-<!DOCTYPE html>
-<html lang="{{#if (eq page.attributes.lang 'de-de')}}de{{else}}en{{/if}}">
-  <head>
-{{> head defaultPageTitle='Untitled'}}
-  </head>
-  <body class="article{{#with (or page.attributes.role page.role)}} {{{this}}}{{/with}}">
-{{> header}}
-{{> body}}
-{{> footer}}
-  </body>
-</html>
+{{> default }}

--- a/src/partials/404.hbs
+++ b/src/partials/404.hbs
@@ -1,0 +1,14 @@
+<h1 class="page">{{{or page.title 'Page Not Found'}}}</h1>
+<div class="paragraph">
+    <p>
+        The page you&#8217;re looking for does not exist. It may have been moved.
+    </p>
+</div>
+<div class="paragraph">
+    <p>
+        If you arrived on this page by clicking on a link, please notify the owner of the site that the link is
+        broken.
+        If you typed the URL of this page manually, please double check that you entered the address
+        correctly.
+    </p>
+</div>

--- a/src/partials/article.hbs
+++ b/src/partials/article.hbs
@@ -1,29 +1,10 @@
 <article class="doc" data-elastic-name="article_content">
     {{#if (eq page.layout 'search')}}
-        <div class="search_head row mb-3">
-          <div class="seach_text col-sm-8 text-left">
-            <div class="search-result-container">{{ i18n page.attributes.lang 'search_query' }} <span id="searche"></span></div>
-            <span id="searchnores">0</span> {{ i18n page.attributes.lang 'search_results' }} (<span id="searchnotime">0</span> {{ i18n page.attributes.lang 'search_seconds' }})</span>
-          </div>
-          <div class="seach-text col-sm-4 text-right">
-            <button class="filtering">{{ i18n page.attributes.lang 'search_sort_by_relevance' }}</button>
-          </div>
-        </div>
-        <div id="search-page-results"></div>
-        <div id="search-page-pagination" class="text-center"></div>
+        {{> search }}
     {{else if (eq page.layout 'overview')}}
         {{> overview }}
     {{else if (eq page.layout '404')}}
-        <h1 class="page">{{{or page.title 'Page Not Found'}}}</h1>
-        <div class="paragraph">
-            <p>The page you&#8217;re looking for does not exist. It may have been moved.</p>
-        </div>
-        <div class="paragraph">
-            <p>If you arrived on this page by clicking on a link, please notify the owner of the site that the link is
-                broken.
-                If you typed the URL of this page manually, please double check that you entered the address
-                correctly.</p>
-        </div>
+        {{> 404 }}
     {{else}}
         {{#with page.title}}
             <h1 class="page">{{{this}}}</h1>

--- a/src/partials/article.hbs
+++ b/src/partials/article.hbs
@@ -11,6 +11,8 @@
         </div>
         <div id="search-page-results"></div>
         <div id="search-page-pagination" class="text-center"></div>
+    {{else if (eq page.layout 'overview')}}
+        {{> overview }}
     {{else if (eq page.layout '404')}}
         <h1 class="page">{{{or page.title 'Page Not Found'}}}</h1>
         <div class="paragraph">

--- a/src/partials/default.hbs
+++ b/src/partials/default.hbs
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="{{#if (eq page.attributes.lang 'de-de')}}de{{else}}en{{/if}}">
+  <head>
+{{> head defaultPageTitle='Untitled'}}
+  </head>
+  <body class="article{{#with (or page.attributes.role page.role)}} {{{this}}}{{/with}}">
+{{> header}}
+{{> body}}
+{{> footer}}
+  </body>
+</html>

--- a/src/partials/overview.hbs
+++ b/src/partials/overview.hbs
@@ -4,7 +4,8 @@
         <div class="sectionbody">
             <div class="paragraph">
                 <p>
-                    Willkommen im Themenbereich Amazon. Hier findest du folgende Informationen:
+                    {{ i18n page.attributes.lang 'overview_page_intro_1' }} <em>{{{this}}}</em>.
+                    {{ i18n page.attributes.lang 'overview_page_intro_2' }}
                 </p>
             </div>
             <div class="ulist" id="child-pages-list"></div>

--- a/src/partials/overview.hbs
+++ b/src/partials/overview.hbs
@@ -1,0 +1,13 @@
+{{#with page.title}}
+    <h1 class="page">{{{this}}}</h1>
+    <div id="preamble">
+        <div class="sectionbody">
+            <div class="paragraph">
+                <p>
+                    Willkommen im Themenbereich Amazon. Hier findest du folgende Informationen:
+                </p>
+            </div>
+            <div class="ulist" id="child-pages-list"></div>
+        </div>
+    </div>
+{{/with}}

--- a/src/partials/search.hbs
+++ b/src/partials/search.hbs
@@ -1,0 +1,11 @@
+<div class="search_head row mb-3">
+    <div class="seach_text col-sm-8 text-left">
+        <div class="search-result-container">{{ i18n page.attributes.lang 'search_query' }} <span id="searche"></span></div>
+        <span id="searchnores">0</span> {{ i18n page.attributes.lang 'search_results' }} (<span id="searchnotime">0</span> {{ i18n page.attributes.lang 'search_seconds' }})</span>
+    </div>
+    <div class="seach-text col-sm-4 text-right">
+        <button class="filtering">{{ i18n page.attributes.lang 'search_sort_by_relevance' }}</button>
+    </div>
+</div>
+<div id="search-page-results"></div>
+<div id="search-page-pagination" class="text-center"></div>


### PR DESCRIPTION
- Adds an overview layout. This layout fetches all child pages of the current page from the navigation tree and displays them as a list.
- Refactors the layouts to avoid duplicate code. The `default`, `search` and `overview` layouts now all use the new `default` partial as a basis. The `article` partial determines which type of layout to actually use.