### PR TITLE
fix: i18n fallback

### DIFF
--- a/src/helpers/i18n.js
+++ b/src/helpers/i18n.js
@@ -9,7 +9,7 @@ module.exports = (...data) => {
   } else if (path.includes('plenty-docs-ui')) {
     trans = require(path + '/public/_/lang/' + currentLang + '.json')
   } else {
-    trans = require(path + '/build/' + currentLang + '/_/lang/' + currentLang + '.json')
+    return trans
   }
   return trans[data[1]]
 }


### PR DESCRIPTION
- Returns the default string when building Antora projects locally.
- Less elegant than locating the lang files, but seems difficult in JS.