### PR TITLE
fix: toggle search bar on resize

### DIFF
--- a/src/js/11-toggle-search-on-resize.js
+++ b/src/js/11-toggle-search-on-resize.js
@@ -1,0 +1,12 @@
+function toggleSearchBarOnResize () {
+  const searchBar = document.getElementById('searchbar')
+  const mediaQuery = window.matchMedia('(min-width: 1024px)')
+
+  if (!mediaQuery.matches) {
+    searchBar.classList.add('d-none')
+  } else {
+    searchBar.classList.remove('d-none')
+  }
+}
+
+window.addEventListener('resize', toggleSearchBarOnResize)


### PR DESCRIPTION
Fixes search bar overlapping the screen when decreasing browser width