### PR TITLE
fix: hyphens on auto word breaks

### DIFF
--- a/src/css/doc.css
+++ b/src/css/doc.css
@@ -762,8 +762,11 @@
   hyphens: none;
 }
 
-.doc th.tableblock,
+.doc th.tableblock {
+  hyphens: none;
+}
 .doc td.tableblock {
+  hyphens: auto;
   word-break: break-word; /* overflow-wrap for table cells; gives space higher precedence than hyphen opportunity */
 }
 


### PR DESCRIPTION
- Disables hyphenation in table headers
- Allows hyphenation & word breaks in table rows