### PR TITLE
fix: table styling

### DIFF
--- a/src/css/doc.css
+++ b/src/css/doc.css
@@ -769,6 +769,11 @@
   hyphens: auto;
   word-break: break-word; /* overflow-wrap for table cells; gives space higher precedence than hyphen opportunity */
 }
+.doc td.tableblock .content .paragraph p {
+  /* Required for cells that use the a attribute to render their contents as nested Asciidoc documents */
+  hyphens: auto;
+  word-break: break-word;
+}
 
 .doc .tableblock caption {
   caption-side: top;


### PR DESCRIPTION
When using the a attribute, Asciidoctor renders the contents of a table cell as a standalone Asciidoc document. This means the selectors change.
https://docs.asciidoctor.org/asciidoc/latest/tables/format-column-content/