### PR TITLE
fix: search request payload

### DIFF
--- a/src/js/11-elastic-search.js
+++ b/src/js/11-elastic-search.js
@@ -165,9 +165,10 @@ function translateKey (locale, key) {
         })
 
         if (document.getElementById('search-page-results')) {
-          const urlResult = window.location.search.split('?query=')[1]
+          let urlResult = decodeURI(window.location.search.split('?query=')[1])
           let urlPage = 1
           if (urlResult.includes('page=')) {
+            urlResult = urlResult.split('page=')[0].split('&')[0]
             urlPage = parseInt(urlResult.split('page=')[1].split('&')[0])
           }
           elasticSearch.setOptions(urlPage)


### PR DESCRIPTION
Accounts for specials characters in search queries.
Removes page string from search queries.